### PR TITLE
[API 변경 작업]트랙별 이미지 API 변경

### DIFF
--- a/bcsdlab_page/config/dev.env.js
+++ b/bcsdlab_page/config/dev.env.js
@@ -4,5 +4,6 @@ const prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
-  ROOT_API: '"https://api.koreatech.in/"'
+  ROOT_API: '"https://api.koreatech.in/"',
+  INTERNAL_API: '"https://api.internal.bcsdlab.com/"'
 })

--- a/bcsdlab_page/config/prod.env.js
+++ b/bcsdlab_page/config/prod.env.js
@@ -1,5 +1,6 @@
 'use strict'
 module.exports = {
   NODE_ENV: '"production"',
-  ROOT_API: '"https://api.koreatech.in/"'
+  ROOT_API: '"https://api.koreatech.in/"',
+  INTERNAL_API: '"https://api.internal.bcsdlab.com/"'
 }

--- a/bcsdlab_page/src/api/api.js
+++ b/bcsdlab_page/src/api/api.js
@@ -1,8 +1,9 @@
 import axios from 'axios/index'
 const API_PATH = process.env.ROOT_API
+const INTERNAL_API_PATH = process.env.INTERNAL_API
 
 export function getMembers () {
-  return axios.get(`${API_PATH}members`)
+  return axios.get(`${INTERNAL_API_PATH}members/v2`)
 }
 
 export function getActivites (year) {

--- a/bcsdlab_page/src/components/SpaComponents/TrackPage/TrackPage.vue
+++ b/bcsdlab_page/src/components/SpaComponents/TrackPage/TrackPage.vue
@@ -74,7 +74,7 @@
             <div
               class="members__profile-card mentor-card"
               v-for="(member, index) in members"
-              v-if="member.position == 'Mentor'"
+              v-if="member.position == 'MENTOR'"
               :key="index">
               <img
                 class="members__profile-img"
@@ -90,7 +90,7 @@
             <div
               v-for="(member, index) in members"
               class="members__profile-card regular-card"
-              v-if="member.position == 'Regular'"
+              v-if="member.position == 'REGULAR'"
               :key="index">
               <img
                 class="members__profile-img"
@@ -232,9 +232,9 @@ export default {
       else if (track === 'iOS') id = 8
       if (track) {
         result = await api.getTrackInfo(id)
-        let allMember = result.data.Members
+        let allMember = await api.getMembers()
         this.teckStacks = result.data.TechStacks
-        this.members = allMember.filter(member => member.track === track.split('-').join(''))
+        this.members = allMember.data.filter(item => item.track === track.split('-').join(''))
       }
       this.show = true
     }


### PR DESCRIPTION

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/bc391473-746b-4f3c-a6b1-37dae23797e7">

새롭게 개편된 [인터널 API](https://api.internal.bcsdlab.com/swagger-ui/index.html#/%ED%9A%8C%EC%9B%90%20%EA%B4%80%EB%A6%AC%20API/getMembers_1)
로 멤버갑 불려오도록 정상 반영되었었습니다.